### PR TITLE
Added validation of phone/email/city for for donation and volunteer forms

### DIFF
--- a/donations/models.py
+++ b/donations/models.py
@@ -1,9 +1,10 @@
 from django.db import models
+from django.core.validators import RegexValidator
 
 class Donation(models.Model):
     name = models.CharField(max_length=100, help_text="Name of donor or business")
-    phone = models.CharField(max_length=20)
-    location = models.CharField(max_length=200)
+    phone = models.CharField(max_length=20, validators=[RegexValidator(regex=r'^\d{10,15}$', message='Phone number must be 10–15 digits only')])
+    location = models.CharField(max_length=200, validators=[RegexValidator(regex=r'^[A-Za-z\s]+$',message='City name must contain only letters and spaces')])
     food_description = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
     fulfilled = models.BooleanField(default=False)

--- a/templates/donations/donate_food.html
+++ b/templates/donations/donate_food.html
@@ -67,6 +67,13 @@
   <div class="alert alert-success">✅ Thank you for donating food! We’ll reach out soon.</div>
   {% endif %}
 
+  {% if form.errors %}
+    <div class="alert alert-danger">
+      Please correct the errors below and resubmit the form.
+    </div>
+  {% endif %}
+
+
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/templates/volunteers/join_team.html
+++ b/templates/volunteers/join_team.html
@@ -75,6 +75,12 @@
   <div class="alert alert-success">🎉 Thanks for joining! We'll be in touch soon.</div>
   {% endif %}
 
+  {% if form.errors %}
+    <div class="alert alert-danger">
+      Please correct the errors below and resubmit the form.
+    </div>
+  {% endif %}
+
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -1,9 +1,10 @@
 from django.db import models
+from django.core.validators import RegexValidator, EmailValidator
 
 class Volunteer(models.Model):
     full_name = models.CharField(max_length=100)
-    email = models.EmailField()
-    phone = models.CharField(max_length=20)
+    email = models.EmailField(validators=[EmailValidator(message="Enter a valid email address")])
+    phone = models.CharField(max_length=20,validators=[RegexValidator(regex=r'^\d{10,15}$',message='Phone number must be 10–15 digits only.')])
     motivation = models.TextField(blank=True, null=True)
     joined_at = models.DateTimeField(auto_now_add=True)
 


### PR DESCRIPTION
resolved issue #2 

###Changes made:
This pull request implements validation and feedback improvements for the donation and volunteer forms:

#### Donation Form
- The phone number validation where it must be between 10 to 15 digits.
- The location field only allows letters and spaces.
- If there are any input errors, the form shows clear messages.

#### Volunteer Form
- The email must be valid, and the phone number must be digits only.
- Proper error messages shown on invalid input

The invalid inputs are handled as shown in screenshots:

<img width="1890" height="982" alt="Image" src="https://github.com/user-attachments/assets/61a16d1e-fa93-4c53-b9de-a21ccf93b571" />
<img width="1861" height="955" alt="Image" src="https://github.com/user-attachments/assets/27b59022-3f93-4b69-81e8-a4c05e18ef74" />
